### PR TITLE
include cmath for definition of abs

### DIFF
--- a/masa-core-1.3.9.1024/src/common/io/BufferLogger.hpp
+++ b/masa-core-1.3.9.1024/src/common/io/BufferLogger.hpp
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <string>
+#include <cmath>
 using namespace std;
 
 #include "Buffer2.hpp"


### PR DESCRIPTION
GCC 6.4 gives build error that overload abs(float) wasn't found. It was looking at integer overloads of abs in string header. The std::abs(float) is definied in cmath.